### PR TITLE
Revert `formatted_newsletter` implementation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ In this repo, `raw_zen_quotes` and `selected_quotes` are part of an asset-orient
       task_ids=["selected_quotes"],
       key="return_value",
       include_prior_dates=True,
-   )[0]
+   )
    logger.info("Before selected_quotes %s", selected_quotes)
 
    newsletter_template_path = object_storage_path / "newsletter_template.txt"


### PR DESCRIPTION
After we merged #10 to fix the backfill, the `formatted_newsletter` function stopped working.

 We are reverting the #9 change, so the AF3 demo works with runtime 3.0-1 (but not 3.0-2 - this version has a backfill problem).