### PR TITLE
`logical_date` fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ In this repo, `raw_zen_quotes` and `selected_quotes` are part of an asset-orient
       conn_id=OBJECT_STORAGE_CONN_ID,
    )
 
-   date = context["dag_run"].run_after.strftime("%Y-%m-%d")
+   date = context["dag_run"].logical_date.strftime("%Y-%m-%d")
 
    selected_quotes = context["ti"].xcom_pull(
       dag_id="selected_quotes",

--- a/dags/personalize_newsletter.py
+++ b/dags/personalize_newsletter.py
@@ -125,7 +125,7 @@ def personalize_newsletter():
     ) -> None:
         from airflow.sdk import ObjectStoragePath
 
-        date = context["dag_run"].run_after.strftime(
+        date = context["dag_run"].logical_date.strftime(
             "%Y-%m-%d"
         )
 

--- a/solutions/create_newsletter_solution.py
+++ b/solutions/create_newsletter_solution.py
@@ -70,7 +70,7 @@ def formatted_newsletter(context: dict) -> None:
         conn_id=OBJECT_STORAGE_CONN_ID,
     )
 
-    date = context["dag_run"].run_after.strftime("%Y-%m-%d")
+    date = context["dag_run"].logical_date.strftime("%Y-%m-%d")
 
     selected_quotes = context["ti"].xcom_pull(
         dag_id="selected_quotes",

--- a/solutions/personalize_newsletter_genai.py
+++ b/solutions/personalize_newsletter_genai.py
@@ -150,7 +150,7 @@ def personalize_newsletter_genai():
         motivation = user["motivation"]
         favorite_sci_fi_character = user["favorite_sci_fi_character"]
         series = favorite_sci_fi_character.split(" (")[1].replace(")", "")
-        date = context["dag_run"].run_after.strftime("%Y-%m-%d")
+        date = context["dag_run"].logical_date.strftime("%Y-%m-%d")
 
         object_storage_path = ObjectStoragePath(
             f"{OBJECT_STORAGE_SYSTEM}://{OBJECT_STORAGE_PATH_NEWSLETTER}",
@@ -223,7 +223,7 @@ def personalize_newsletter_genai():
 
         from airflow.io.path import ObjectStoragePath
 
-        date = context["dag_run"].run_after.strftime("%Y-%m-%d")
+        date = context["dag_run"].logical_date.strftime("%Y-%m-%d")
 
         id = user["id"]
         name = user["name"]

--- a/solutions/personalize_newsletter_solution.py
+++ b/solutions/personalize_newsletter_solution.py
@@ -124,7 +124,7 @@ def personalize_newsletter():
     ) -> None:
         from airflow.sdk import ObjectStoragePath
 
-        date = context["dag_run"].run_after.strftime(
+        date = context["dag_run"].logical_date.strftime(
             "%Y-%m-%d"
         )
 


### PR DESCRIPTION
Newsletters for different days weren't being created during a backfill - due to using `run_after` instead of `dag_run.logical_date`. I haven't tested this though :| but it should fix that?