### PR TITLE
Use asset event extra for idempotency

### DIFF
--- a/dags/create_newsletter.py
+++ b/dags/create_newsletter.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 from airflow.sdk import asset, Asset, Metadata
@@ -13,8 +12,6 @@ OBJECT_STORAGE_PATH_NEWSLETTER = os.getenv(
     default="include/newsletter",
 )
 
-
-logger = logging.getLogger(__name__)
 
 
 @asset(schedule="@daily")
@@ -36,7 +33,7 @@ def raw_zen_quotes(context: dict):
 
 
 @asset(schedule=[raw_zen_quotes])
-def selected_quotes(context: dict) -> dict:
+def selected_quotes(context: dict):
     """
     Transforms the extracted raw_zen_quotes.
     """
@@ -49,7 +46,6 @@ def selected_quotes(context: dict) -> dict:
         include_prior_dates=True,
     )
 
-    logger.info("Before quote_character_counts %s", raw_zen_quotes)
     quotes_character_counts = [int(quote["c"]) for quote in raw_zen_quotes]
     median = np.median(quotes_character_counts)
 

--- a/dags/personalize_newsletter.py
+++ b/dags/personalize_newsletter.py
@@ -125,8 +125,10 @@ def personalize_newsletter():
     ) -> None:
         from airflow.sdk import ObjectStoragePath
 
-        date = context["dag_run"].run_after.strftime(
-            "%Y-%m-%d"
+        # fetch the run date of the pipeline from the triggering asset event
+        run_date = (
+            context["triggering_asset_events"][Asset("formatted_newsletter")][0]
+            .extra["run_date"]
         )
 
         id = user["id"]
@@ -158,7 +160,7 @@ def personalize_newsletter():
 
         daily_newsletter_path = (
             object_storage_path
-            / f"{date}_newsletter.txt"
+            / f"{run_date}_newsletter.txt"
         )
 
         generic_content = (
@@ -172,7 +174,7 @@ def personalize_newsletter():
 
         personalized_newsletter_path = (
             object_storage_path
-            / f"{date}_newsletter_userid_{id}.txt"
+            / f"{run_date}_newsletter_userid_{id}.txt"
         )
 
         personalized_newsletter_path.write_text(

--- a/solutions/create_newsletter_solution.py
+++ b/solutions/create_newsletter_solution.py
@@ -10,7 +10,6 @@ OBJECT_STORAGE_PATH_NEWSLETTER = os.getenv(
     default="include/newsletter",
 )
 
-
 @asset(schedule="@daily")
 def raw_zen_quotes(context: dict):
     """

--- a/solutions/create_newsletter_solution.py
+++ b/solutions/create_newsletter_solution.py
@@ -1,7 +1,7 @@
-from airflow.sdk import asset
+from airflow.sdk import asset, Asset, Metadata
 import os
 
-# set these enviroment variables in order to store the newsletter 
+# set these enviroment variables in order to store the newsletter
 # in cloud object storage instead of the local filesystem
 OBJECT_STORAGE_SYSTEM = os.getenv("OBJECT_STORAGE_SYSTEM", default="file")
 OBJECT_STORAGE_CONN_ID = os.getenv("OBJECT_STORAGE_CONN_ID", default=None)
@@ -12,7 +12,7 @@ OBJECT_STORAGE_PATH_NEWSLETTER = os.getenv(
 
 
 @asset(schedule="@daily")
-def raw_zen_quotes() -> list[dict]:
+def raw_zen_quotes(context: dict):
     """
     Extracts a random set of quotes.
     """
@@ -21,15 +21,19 @@ def raw_zen_quotes() -> list[dict]:
     r = requests.get("https://zenquotes.io/api/quotes/random")
     quotes = r.json()
 
+    run_date = context["dag_run"].logical_date.strftime("%Y-%m-%d")
+
+    # attach the run date to the asset event
+    yield Metadata(Asset("raw_zen_quotes"), {"run_date": run_date})
+
     return quotes
 
 
 @asset(schedule=[raw_zen_quotes])
-def selected_quotes(context: dict) -> dict:
+def selected_quotes(context: dict):
     """
     Transforms the extracted raw_zen_quotes.
     """
-
     import numpy as np
 
     raw_zen_quotes = context["ti"].xcom_pull(
@@ -50,16 +54,25 @@ def selected_quotes(context: dict) -> dict:
     short_quote = [quote for quote in raw_zen_quotes if int(quote["c"]) < median][0]
     long_quote = [quote for quote in raw_zen_quotes if int(quote["c"]) > median][0]
 
+    # fetch the run date of the pipeline
+    run_date = context["triggering_asset_events"][Asset("raw_zen_quotes")][0].extra[
+        "run_date"
+    ]
+
+    # attach the run date to the asset
+    yield Metadata(Asset("selected_quotes"), {"run_date": run_date})
+
     return {
         "median_q": median_quote,
         "short_q": short_quote,
         "long_q": long_quote,
     }
 
+
 @asset(
     schedule=[selected_quotes],
 )
-def formatted_newsletter(context: dict) -> None:
+def formatted_newsletter(context: dict):
     """
     Formats the newsletter.
     """
@@ -70,14 +83,17 @@ def formatted_newsletter(context: dict) -> None:
         conn_id=OBJECT_STORAGE_CONN_ID,
     )
 
-    date = context["dag_run"].run_after.strftime("%Y-%m-%d")
-
     selected_quotes = context["ti"].xcom_pull(
         dag_id="selected_quotes",
         task_ids="selected_quotes",
         key="return_value",
         include_prior_dates=True,
     )
+
+    # fetch the run date of the pipeline
+    run_date = context["triggering_asset_events"][Asset("selected_quotes")][0].extra[
+        "run_date"
+    ]
 
     newsletter_template_path = object_storage_path / "newsletter_template.txt"
 
@@ -90,9 +106,12 @@ def formatted_newsletter(context: dict) -> None:
         quote_author_2=selected_quotes["median_q"]["a"],
         quote_text_3=selected_quotes["long_q"]["q"],
         quote_author_3=selected_quotes["long_q"]["a"],
-        date=date,
+        date=run_date,
     )
 
-    date_newsletter_path = object_storage_path / f"{date}_newsletter.txt"
+    date_newsletter_path = object_storage_path / f"{run_date}_newsletter.txt"
 
     date_newsletter_path.write_text(newsletter)
+
+    # attach the run date to the asset event
+    yield Metadata(Asset("formatted_newsletter"), {"run_date": run_date})

--- a/solutions/personalize_newsletter_genai.py
+++ b/solutions/personalize_newsletter_genai.py
@@ -223,7 +223,11 @@ def personalize_newsletter_genai():
 
         from airflow.io.path import ObjectStoragePath
 
-        date = context["dag_run"].run_after.strftime("%Y-%m-%d")
+        # fetch the run date of the pipeline from the triggering asset event
+        run_date = (
+            context["triggering_asset_events"][Asset("formatted_newsletter")][0]
+            .extra["run_date"]
+        )
 
         id = user["id"]
         name = user["name"]
@@ -248,7 +252,7 @@ def personalize_newsletter_genai():
             conn_id=OBJECT_STORAGE_CONN_ID,
         )
 
-        daily_newsletter_path = object_storage_path / f"{date}_newsletter.txt"
+        daily_newsletter_path = object_storage_path / f"{run_date}_newsletter.txt"
 
         generic_content = daily_newsletter_path.read_text()
 
@@ -269,7 +273,7 @@ def personalize_newsletter_genai():
         )
 
         personalized_newsletter_path = (
-            object_storage_path / f"{date}_newsletter_userid_{id}.txt"
+            object_storage_path / f"{run_date}_newsletter_userid_{id}.txt"
         )
 
         personalized_newsletter_path.write_text(updated_content)

--- a/solutions/personalize_newsletter_solution.py
+++ b/solutions/personalize_newsletter_solution.py
@@ -124,8 +124,10 @@ def personalize_newsletter():
     ) -> None:
         from airflow.sdk import ObjectStoragePath
 
-        date = context["dag_run"].run_after.strftime(
-            "%Y-%m-%d"
+        # fetch the run date of the pipeline from the triggering asset event
+        run_date = (
+            context["triggering_asset_events"][Asset("formatted_newsletter")][0]
+            .extra["run_date"]
         )
 
         id = user["id"]
@@ -157,7 +159,7 @@ def personalize_newsletter():
 
         daily_newsletter_path = (
             object_storage_path
-            / f"{date}_newsletter.txt"
+            / f"{run_date}_newsletter.txt"
         )
 
         generic_content = (
@@ -171,7 +173,7 @@ def personalize_newsletter():
 
         personalized_newsletter_path = (
             object_storage_path
-            / f"{date}_newsletter_userid_{id}.txt"
+            / f"{run_date}_newsletter_userid_{id}.txt"
         )
 
         personalized_newsletter_path.write_text(


### PR DESCRIPTION
Because the pipeline is asset based the logical_date cannot be used for idempotency purposes. This PR uses the Asset event extra to pass the logical_date of the first asset/dag through the pipeline.